### PR TITLE
Releases and installation script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+on:
+  release:
+    types: [created]
+
+jobs:
+  releases-matrix:
+    name: Release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, darwin/amd64, darwin/arm64
+        goos: [linux, darwin]
+        goarch: ["386", amd64, arm64]
+        exclude:
+          - goarch: "386"
+            goos: darwin
+    steps:
+    - uses: actions/checkout@v3
+    - uses: wangyoucao577/go-release-action@v1.34
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        binary_name: "gql-lint"
+        # extra_files: README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
     - uses: actions/checkout@v3
     - uses: wangyoucao577/go-release-action@v1.34
       with:
+        project_path: "./cmd"
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
         binary_name: "gql-lint"
-        # extra_files: README.md

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,11 @@
+# GQL-lint
+
+## Install
+
+```
+curl https://raw.githubusercontent.com/sketch-hq/gql-lint/lab/releases/install.sh | /bin/bash -s -- <version>
+```
+
+```
+curl https://raw.githubusercontent.com/sketch-hq/gql-lint/lab/releases/install.sh | /bin/bash -s -- v0
+```

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,42 @@
+set -e
+
+VERSION=$1
+
+arch=$(uname -m)
+if [[ $arch == x86_64* ]]; then
+  ARCH="amd64"
+elif  [[ $arch == arm* ]]; then
+  ARCH="arm64"
+else
+  echo "Incompatible architecture: $arch"
+  exit 0
+fi
+
+platform=$(uname -s)
+if [[ $platform == Darwin ]]; then
+  PLATFORM="darwin"
+else
+  PLATFORM="linux"
+fi
+
+
+TARNAME=gql-lint-$VERSION-$PLATFORM-$ARCH.tar.gz
+
+echo Downloading version $VERSION for $PLATFORM-$ARCH
+echo https://github.com/sketch-hq/gql-lint/releases/download/$VERSION/$TARNAME
+echo ---
+
+
+
+curl -SLJO https://github.com/sketch-hq/gql-lint/releases/download/$VERSION/$TARNAME
+
+echo ---
+echo Installing
+echo ---
+
+tar xvzf $TARNAME
+rm $TARNAME
+
+sudo mv gql-lint /usr/local/bin
+
+echo Done!


### PR DESCRIPTION
Releases can be created via the regular GitHub interface. Once the release is created, a github action will build and add all the binaries.

For easy testing, I already built a pre-release for a `v0` version on this branch, so you can install it with:

```
curl https://raw.githubusercontent.com/sketch-hq/gql-lint/lab/releases/install.sh | /bin/bash -s -- v0
```