### PR TITLE
Add support for schema url loading on `gql unused`

### DIFF
--- a/cmd/ops/unused.go
+++ b/cmd/ops/unused.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sketch-hq/gql-lint/input"
 	"github.com/sketch-hq/gql-lint/output"
+	"github.com/sketch-hq/gql-lint/schema"
 	"github.com/sketch-hq/gql-lint/unused"
 	"github.com/spf13/cobra"
 )
@@ -26,17 +27,22 @@ The "queries" argument is a file glob matching one or more graphql query or muta
 
 func init() {
 	Program.AddCommand(unusedCmd)
-	unusedCmd.Flags().StringVar(&flags.schemaFile, schemaFileFlagName, "", "Server's schema file (required)")
+	unusedCmd.Flags().StringVar(&flags.schemaFile, schemaFileFlagName, "", "Server's schema as file or url (required)")
 	unusedCmd.MarkFlagRequired(schemaFileFlagName) //nolint:errcheck // will err if flag doesn't exist
 }
 
 func unusedCmdRun(cmd *cobra.Command, args []string) error {
+	schema, err := schema.Load(flags.schemaFile)
+	if err != nil {
+		return err
+	}
+
 	queryFiles, err := input.QueryFiles(args)
 	if err != nil {
 		return err
 	}
 
-	unusedFields, err := unused.GetUnusedFields(flags.schemaFile, queryFiles)
+	unusedFields, err := unused.GetUnusedFields(schema, queryFiles)
 	if err != nil {
 		return err
 	}

--- a/cmd/testdata/unused.ct
+++ b/cmd/testdata/unused.ct
@@ -6,7 +6,7 @@ Usage:
 
 Flags:
   -h, --help            help for unused
-      --schema string   Server's schema file (required)
+      --schema string   Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -19,7 +19,7 @@ Usage:
 
 Flags:
   -h, --help            help for unused
-      --schema string   Server's schema file (required)
+      --schema string   Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -32,7 +32,7 @@ Usage:
 
 Flags:
   -h, --help            help for unused
-      --schema string   Server's schema file (required)
+      --schema string   Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -146,6 +146,11 @@ func extractFields(set ast.SelectionSet, parentPath string, parentType string, f
 				path = f.Name
 			}
 
+			// This means the field doesn't belong to this schema
+			if f.Definition == nil {
+				continue
+			}
+
 			dep, depReason := isDeprecated(f.Definition.Directives)
 			if !dep {
 				fields = extractFields(f.SelectionSet, path, f.Definition.Type.Name(), fields)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -50,7 +50,7 @@ func TestParseSchemaFile_NotFound(t *testing.T) {
 	is.True(strings.Contains(err.Error(), "open testdata/schemas/not_found.gql: no such file or directory"))
 }
 
-func TestParseQuerySourceDir(t *testing.T) {
+func TestParseQuerySource(t *testing.T) {
 	is := is.New(t)
 
 	schema, err := ParseSchemaFile("testdata/schemas/with_deprecations.gql")
@@ -67,6 +67,18 @@ func TestParseQuerySourceDir(t *testing.T) {
 	is.True(field.IsDeprecated)
 	is.Equal(field.File, "testdata/queries/deprecation.gql")
 	is.Equal(field.Line, 7)
+}
+
+func TestParseQuerySourceDirUnknownFields(t *testing.T) {
+	is := is.New(t)
+
+	schema, err := ParseSchemaFile("testdata/schemas/with_deprecations.gql")
+	is.NoErr(err)
+
+	fields, err := ParseQuerySource([]string{"testdata/queries/for_other_schema.gql"}, schema)
+	is.NoErr(err)
+
+	is.Equal(len(fields), 0)
 }
 
 func TestParseDeprecatedFields(t *testing.T) {

--- a/parser/testdata/queries/for_other_schema.gql
+++ b/parser/testdata/queries/for_other_schema.gql
@@ -1,0 +1,5 @@
+query {
+  unknown(id: 123) {
+    id
+  }
+}

--- a/unused/unused.go
+++ b/unused/unused.go
@@ -2,6 +2,7 @@ package unused
 
 import (
 	"github.com/sketch-hq/gql-lint/parser"
+	"github.com/vektah/gqlparser/v2/ast"
 )
 
 type UnusedField struct {
@@ -14,13 +15,8 @@ func (r unusedRegistry) Record(field parser.SchemaField) {
 	r[field.Name] = UnusedField{Name: field.Name}
 }
 
-func GetUnusedFields(schemaPath string, queriesPaths []string) ([]UnusedField, error) {
+func GetUnusedFields(schema *ast.Schema, queriesPaths []string) ([]UnusedField, error) {
 	unusedFields := make(unusedRegistry)
-
-	schema, err := parser.ParseSchemaFile(schemaPath)
-	if err != nil {
-		return []UnusedField{}, err
-	}
 
 	deprecatedFields := parser.ParseDeprecatedFields(schema)
 

--- a/unused/unused_test.go
+++ b/unused/unused_test.go
@@ -4,18 +4,19 @@ import (
 	"testing"
 
 	"github.com/matryer/is"
+	"github.com/sketch-hq/gql-lint/schema"
 )
 
 func TestGetUnusedFields(t *testing.T) {
 	is := is.New(t)
 
-	unusedFields, err := GetUnusedFields(
-		"testdata/schemas/with_deprecations.gql",
-		[]string{
-			"testdata/queries/one/one.gql",
-			"testdata/queries/deprecation/deprecation.gql",
-		},
-	)
+	schema, err := schema.Load("testdata/schemas/with_deprecations.gql")
+	is.NoErr(err)
+
+	unusedFields, err := GetUnusedFields(schema, []string{
+		"testdata/queries/one/one.gql",
+		"testdata/queries/deprecation/deprecation.gql",
+	})
 	is.NoErr(err)
 
 	is.Equal(len(unusedFields), 1)


### PR DESCRIPTION
Support for loading the schema from a URL was only added to the `deprecation` command.

