### PR TITLE
Add --ignore option to deprecation and unused commands

### DIFF
--- a/cmd/ops/deprecation.go
+++ b/cmd/ops/deprecation.go
@@ -27,7 +27,7 @@ func init() {
 	deprecationsCmd.Flags().StringVar(&flags.schemaFile, schemaFileFlagName, "", "Server's schema as file or url (required)")
 	deprecationsCmd.MarkFlagRequired(schemaFileFlagName) //nolint:errcheck // will err if flag doesn't exist
 
-	deprecationsCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore (as file blob)")
+	deprecationsCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore")
 }
 
 func deprecationsCmdRun(cmd *cobra.Command, args []string) error {

--- a/cmd/ops/deprecation.go
+++ b/cmd/ops/deprecation.go
@@ -18,7 +18,7 @@ var deprecationsCmd = &cobra.Command{
 Find deprecated fields in queries and mutations given a list of files
 
 The "queries" argument is a file glob matching one or more graphql query or mutation files.`,
-	Args: ExactArgs(1, "you must specify at least one file with queries or mutations"),
+	Args: MinimumNArgs(1, "you must specify at least one file with queries or mutations"),
 	RunE: deprecationsCmdRun,
 }
 
@@ -26,6 +26,8 @@ func init() {
 	Program.AddCommand(deprecationsCmd)
 	deprecationsCmd.Flags().StringVar(&flags.schemaFile, schemaFileFlagName, "", "Server's schema as file or url (required)")
 	deprecationsCmd.MarkFlagRequired(schemaFileFlagName) //nolint:errcheck // will err if flag doesn't exist
+
+	deprecationsCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore (as file blob)")
 }
 
 func deprecationsCmdRun(cmd *cobra.Command, args []string) error {
@@ -34,7 +36,7 @@ func deprecationsCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	queryFiles, err := input.QueryFiles(args)
+	queryFiles, err := input.ExpandGlobs(args, flags.ignore)
 	if err != nil {
 		return fmt.Errorf("Error: %s", err)
 	}

--- a/cmd/ops/flags_helpers.go
+++ b/cmd/ops/flags_helpers.go
@@ -7,11 +7,13 @@ const (
 	jsonFormat           = "json"
 	stdoutFormat         = "stdout"
 	xcodeFormat          = "xcode"
+	ignoreFlagName       = "ignore"
 )
 
 var flags = struct {
 	outputFormat string
 	schemaFile   string
+	ignore       []string
 }{}
 
 func setFlagsToDefault() {

--- a/cmd/ops/unused.go
+++ b/cmd/ops/unused.go
@@ -29,6 +29,8 @@ func init() {
 	Program.AddCommand(unusedCmd)
 	unusedCmd.Flags().StringVar(&flags.schemaFile, schemaFileFlagName, "", "Server's schema as file or url (required)")
 	unusedCmd.MarkFlagRequired(schemaFileFlagName) //nolint:errcheck // will err if flag doesn't exist
+
+	unusedCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore (as file blob)")
 }
 
 func unusedCmdRun(cmd *cobra.Command, args []string) error {
@@ -37,7 +39,7 @@ func unusedCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	queryFiles, err := input.QueryFiles(args)
+	queryFiles, err := input.ExpandGlobs(args, flags.ignore)
 	if err != nil {
 		return err
 	}

--- a/cmd/ops/unused.go
+++ b/cmd/ops/unused.go
@@ -30,7 +30,7 @@ func init() {
 	unusedCmd.Flags().StringVar(&flags.schemaFile, schemaFileFlagName, "", "Server's schema as file or url (required)")
 	unusedCmd.MarkFlagRequired(schemaFileFlagName) //nolint:errcheck // will err if flag doesn't exist
 
-	unusedCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore (as file blob)")
+	unusedCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore")
 }
 
 func unusedCmdRun(cmd *cobra.Command, args []string) error {

--- a/cmd/testdata/deprecation.ct
+++ b/cmd/testdata/deprecation.ct
@@ -5,8 +5,9 @@ Usage:
   gql-lint deprecation [flags] queries
 
 Flags:
-  -h, --help            help for deprecation
-      --schema string   Server's schema as file or url (required)
+  -h, --help                 help for deprecation
+      --ignore stringArray   Files to ignore (as file blob)
+      --schema string        Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -18,8 +19,9 @@ Usage:
   gql-lint deprecation [flags] queries
 
 Flags:
-  -h, --help            help for deprecation
-      --schema string   Server's schema as file or url (required)
+  -h, --help                 help for deprecation
+      --ignore stringArray   Files to ignore (as file blob)
+      --schema string        Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -31,8 +33,9 @@ Usage:
   gql-lint deprecation [flags] queries
 
 Flags:
-  -h, --help            help for deprecation
-      --schema string   Server's schema as file or url (required)
+  -h, --help                 help for deprecation
+      --ignore stringArray   Files to ignore (as file blob)
+      --schema string        Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -50,8 +53,9 @@ Usage:
   gql-lint deprecation [flags] queries
 
 Flags:
-  -h, --help            help for deprecation
-      --schema string   Server's schema as file or url (required)
+  -h, --help                 help for deprecation
+      --ignore stringArray   Files to ignore (as file blob)
+      --schema string        Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -60,6 +64,10 @@ Global Flags:
 $ gql-lint deprecation --output json --schema testdata/schemas/with_deprecations.gql testdata/queries/author/*.gql
 [{"field":"author.books.title","file":"testdata/queries/author/author.gql","line":7,"reason":"untitled books are better"}]
 
+# ignores a given file glob
+$ gql-lint deprecation --output json --schema testdata/schemas/with_deprecations.gql --ignore testdata/queries/author/author_id.gql testdata/queries/author/*.gql
+[{"field":"author.books.title","file":"testdata/queries/author/author.gql","line":7,"reason":"untitled books are better"}]
+
 # outputs deprecations as xcode
-$ gql-lint deprecation --output xcode --schema testdata/schemas/with_deprecations.gql testdata/queries/author/*.gql
+$ gql-lint deprecation --output xcode --schema testdata/schemas/with_deprecations.gql  testdata/queries/author/*.gql
 testdata/queries/author/author.gql:7: warning: author.books.title is deprecated - Reason: untitled books are better

--- a/cmd/testdata/deprecation.ct
+++ b/cmd/testdata/deprecation.ct
@@ -6,7 +6,7 @@ Usage:
 
 Flags:
   -h, --help                 help for deprecation
-      --ignore stringArray   Files to ignore (as file blob)
+      --ignore stringArray   Files to ignore
       --schema string        Server's schema as file or url (required)
 
 Global Flags:
@@ -20,7 +20,7 @@ Usage:
 
 Flags:
   -h, --help                 help for deprecation
-      --ignore stringArray   Files to ignore (as file blob)
+      --ignore stringArray   Files to ignore
       --schema string        Server's schema as file or url (required)
 
 Global Flags:
@@ -34,7 +34,7 @@ Usage:
 
 Flags:
   -h, --help                 help for deprecation
-      --ignore stringArray   Files to ignore (as file blob)
+      --ignore stringArray   Files to ignore
       --schema string        Server's schema as file or url (required)
 
 Global Flags:
@@ -54,7 +54,7 @@ Usage:
 
 Flags:
   -h, --help                 help for deprecation
-      --ignore stringArray   Files to ignore (as file blob)
+      --ignore stringArray   Files to ignore
       --schema string        Server's schema as file or url (required)
 
 Global Flags:

--- a/cmd/testdata/queries/author/author_id.gql
+++ b/cmd/testdata/queries/author/author_id.gql
@@ -1,0 +1,5 @@
+query {
+  author(id: 123) {
+    id
+  }
+}

--- a/cmd/testdata/unused.ct
+++ b/cmd/testdata/unused.ct
@@ -6,7 +6,7 @@ Usage:
 
 Flags:
   -h, --help                 help for unused
-      --ignore stringArray   Files to ignore (as file blob)
+      --ignore stringArray   Files to ignore
       --schema string        Server's schema as file or url (required)
 
 Global Flags:
@@ -20,7 +20,7 @@ Usage:
 
 Flags:
   -h, --help                 help for unused
-      --ignore stringArray   Files to ignore (as file blob)
+      --ignore stringArray   Files to ignore
       --schema string        Server's schema as file or url (required)
 
 Global Flags:
@@ -34,7 +34,7 @@ Usage:
 
 Flags:
   -h, --help                 help for unused
-      --ignore stringArray   Files to ignore (as file blob)
+      --ignore stringArray   Files to ignore
       --schema string        Server's schema as file or url (required)
 
 Global Flags:

--- a/cmd/testdata/unused.ct
+++ b/cmd/testdata/unused.ct
@@ -5,8 +5,9 @@ Usage:
   gql-lint unused [flags] queries
 
 Flags:
-  -h, --help            help for unused
-      --schema string   Server's schema as file or url (required)
+  -h, --help                 help for unused
+      --ignore stringArray   Files to ignore (as file blob)
+      --schema string        Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -18,8 +19,9 @@ Usage:
   gql-lint unused [flags] queries
 
 Flags:
-  -h, --help            help for unused
-      --schema string   Server's schema as file or url (required)
+  -h, --help                 help for unused
+      --ignore stringArray   Files to ignore (as file blob)
+      --schema string        Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -31,8 +33,9 @@ Usage:
   gql-lint unused [flags] queries
 
 Flags:
-  -h, --help            help for unused
-      --schema string   Server's schema as file or url (required)
+  -h, --help                 help for unused
+      --ignore stringArray   Files to ignore (as file blob)
+      --schema string        Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -44,6 +47,10 @@ $ gql-lint unused --schema testdata/schemas/with_deprecations.gql testdata/queri
 # outputs deprecations as json
 $ gql-lint unused --output json --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql
 [{"field":"Book.title"}]
+
+# ignores a given file blob
+$ gql-lint unused --output json --schema testdata/schemas/with_deprecations.gql --ignore testdata/queries/unused/without_title/*.gql testdata/queries/unused/**/*.gql
+[]
 
 # outputs success message if no unused fields are found
 $ gql-lint unused --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/with_title/with_title.gql testdata/queries/unused/without_title/without_title.gql

--- a/input/input.go
+++ b/input/input.go
@@ -103,7 +103,7 @@ func expand(pattern string) ([]string, error) {
 						return err
 					}
 
-					hits = append(hits, strings.Replace(path, `//`, `/`, -1))
+					hits = append(hits, filepath.Clean(path))
 
 					return nil
 				})

--- a/input/input.go
+++ b/input/input.go
@@ -11,8 +11,17 @@ type command interface {
 	InOrStdin() io.Reader
 }
 
-func QueryFiles(args []string) ([]string, error) {
+func ExpandGlobs(args []string, ignore []string) ([]string, error) {
 	var files []string
+
+	if len(ignore) > 0 {
+		var err error
+		ignore, err = ExpandGlobs(ignore, []string{})
+		if err != nil {
+			return files, err
+		}
+	}
+
 	for _, source := range args {
 		if strings.Contains(source, "*") {
 			matches, err := glob(source)
@@ -20,13 +29,35 @@ func QueryFiles(args []string) ([]string, error) {
 				return files, err
 			}
 
-			files = append(files, matches...)
-		} else {
+			files = append(files, filter(matches, ignore)...)
+		} else if !contains(ignore, source) {
 			files = append(files, source)
 		}
 	}
 
 	return unique(files), nil
+}
+
+func filter(in []string, ignore []string) []string {
+	var out []string
+
+	for _, s := range in {
+		if !contains(ignore, s) {
+			out = append(out, s)
+		}
+	}
+
+	return out
+}
+
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
 }
 
 func unique(input []string) []string {
@@ -72,7 +103,7 @@ func expand(pattern string) ([]string, error) {
 						return err
 					}
 
-					hits = append(hits, path)
+					hits = append(hits, strings.Replace(path, `//`, `/`, -1))
 
 					return nil
 				})

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -10,9 +10,10 @@ func TestQueryFiles(t *testing.T) {
 	is := is.New(t)
 
 	tests := []struct {
-		name string
-		args []string
-		want []string
+		name   string
+		args   []string
+		ignore []string
+		want   []string
 	}{
 		{
 			name: "expands directories",
@@ -34,10 +35,17 @@ func TestQueryFiles(t *testing.T) {
 			args: []string{"testdata/**/*.gql"},
 			want: []string{"testdata/one.gql", "testdata/two.gql", "testdata/nested/one.gql", "testdata/nested/two.gql"},
 		},
+		{
+			name:   "expands nested directories",
+			args:   []string{"testdata/**/*.gql"},
+			ignore: []string{"testdata/**/one.gql"},
+			want:   []string{"testdata/two.gql", "testdata/nested/two.gql"},
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := QueryFiles(tt.args)
+			got, err := ExpandGlobs(tt.args, tt.ignore)
 			is.NoErr(err)
 
 			is.Equal(got, tt.want)


### PR DESCRIPTION
Fixes https://github.com/sketch-hq/Cloud/issues/16076

Usage:

```
$ gql-lint unused --output json --schema path/to/schema.gql --ignore some/pattern_*.gql path/to/**/*.gql
```
