### PR TITLE
Add markdown output to `unused`

### DIFF
--- a/cmd/ops/flags_helpers.go
+++ b/cmd/ops/flags_helpers.go
@@ -6,6 +6,7 @@ const (
 	outputFormatFlagName = "output"
 	jsonFormat           = "json"
 	stdoutFormat         = "stdout"
+	markdownFormat       = "markdown"
 	xcodeFormat          = "xcode"
 	ignoreFlagName       = "ignore"
 )

--- a/cmd/ops/unused.go
+++ b/cmd/ops/unused.go
@@ -53,6 +53,9 @@ func unusedCmdRun(cmd *cobra.Command, args []string) error {
 	case stdoutFormat:
 		unusedStdOut(unusedFields)
 
+	case markdownFormat:
+		unusedMarkdownOut(unusedFields)
+
 	case jsonFormat:
 		err = unusedJSONOut(unusedFields)
 		if err != nil {
@@ -60,7 +63,7 @@ func unusedCmdRun(cmd *cobra.Command, args []string) error {
 		}
 
 	default:
-		return fmt.Errorf("%s is not a valid output format. Choose between json and stdout", flags.outputFormat)
+		return fmt.Errorf("%s is not a valid output format. Choose between json, markdown and stdout", flags.outputFormat)
 	}
 
 	return nil
@@ -91,4 +94,16 @@ func unusedJSONOut(fields []unused.UnusedField) error {
 
 	fmt.Print(string(bytes))
 	return nil
+}
+
+func unusedMarkdownOut(fields []unused.UnusedField) {
+	if len(fields) == 0 {
+		fmt.Println("Nothing can be removed right now")
+		return
+	}
+
+	for _, q := range fields {
+		fmt.Printf("- %s", q.Name)
+		fmt.Println()
+	}
 }

--- a/cmd/testdata/unused.ct
+++ b/cmd/testdata/unused.ct
@@ -59,3 +59,7 @@ Nothing can be removed right now
 # outputs empty json if no unused fields are found
 $ gql-lint unused --output json --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/with_title/with_title.gql testdata/queries/unused/without_title/without_title.gql
 []
+
+# outputs for slack
+$ gql-lint unused --output markdown --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql
+- Book.title

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -52,6 +52,10 @@ func ParseDeprecatedFields(schema *ast.Schema) []SchemaField {
 	var fields []SchemaField
 
 	for name, definition := range schema.Types {
+		if name == "__Directive" {
+			continue
+		}
+
 		if ok, _ := isDeprecated(definition.Directives); ok {
 			fields = append(fields, SchemaField{Name: name})
 		}


### PR DESCRIPTION
Also fixes a tiny bug:
- Ignore `__Directive` type introduced by absinthe
