### PR TITLE
Remove not needed new line in xcode output

### DIFF
--- a/cmd/ops/deprecation.go
+++ b/cmd/ops/deprecation.go
@@ -98,7 +98,7 @@ func deprecationXcodeOut(queryFields parser.QueryFieldList) {
 	for _, q := range queryFields {
 		fmt.Printf("%s:%d: warning: ", q.File, q.Line)
 		fmt.Printf("%s is deprecated ", q.Path)
-		fmt.Printf("- Reason: %s\n", q.DeprecationReason)
+		fmt.Printf("- Reason: %s", q.DeprecationReason)
 		fmt.Println()
 	}
 }

--- a/cmd/ops/diff.go
+++ b/cmd/ops/diff.go
@@ -69,7 +69,7 @@ func diffXcodeOut(out output.Data) {
 	for _, f := range out {
 		fmt.Printf("%s:%d: warning: ", f.File, f.Line)
 		fmt.Printf("%s is deprecated ", f.Field)
-		fmt.Printf("- Reason: %s\n", f.DeprecationReason)
+		fmt.Printf("- Reason: %s", f.DeprecationReason)
 		fmt.Println()
 	}
 }


### PR DESCRIPTION
I was adding a `\n` and also printing a newline. I removed the earlier one as it is easier to miss in a quick look and we don't need the performance difference that would produce (if any, I hope the compiler is smarter than me and joins those statements)