### PR TITLE
Multiple `--schema` support added.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,3 +20,17 @@ This is very useful for reading from files for example :point_down:
 ```
 $ cat query_file_list.txt | xargs gql-lint unused --schema path/to/schema.gql
 ```
+
+## Testing
+
+Run all tests using `make test`.
+
+### Updating cmdtest tests
+
+The "external interface" of the CLI is tested using `cmdtest-go`. If you makes changes to the output such as the help text it can be bothersome to update all the test files manually. Instead you can set an env var that will make `cmdtest-go` recreate the files with the current output:
+
+```sh
+UPDATE_CMD_TESTS=true make test
+```
+
+Remember to manually inspect any difference to ensure the new output is corret.

--- a/cmd/gql-lint_test.go
+++ b/cmd/gql-lint_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/google/go-cmdtest"
 )
 
-// set this to true if you want to update the test cases in `testdata/`
-var update = flag.Bool("update", false, "update test files with results")
+// Run tests with `UPDATE_CMD_TESTS=true make test` to re-generate the cmd test files
+var updateEnv = os.Getenv("UPDATE_CMD_TESTS")
+var update = flag.Bool("update", updateEnv == "true", "update test files with results")
 
 func TestCLI(t *testing.T) {
 	ts, err := cmdtest.Read("testdata")

--- a/cmd/ops/deprecation.go
+++ b/cmd/ops/deprecation.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/sketch-hq/gql-lint/input"
 	"github.com/sketch-hq/gql-lint/output"
-	"github.com/sketch-hq/gql-lint/parser"
 	"github.com/sketch-hq/gql-lint/sources"
 	"github.com/spf13/cobra"
 )
@@ -24,39 +23,52 @@ The "queries" argument is a file glob matching one or more graphql query or muta
 
 func init() {
 	Program.AddCommand(deprecationsCmd)
-	deprecationsCmd.Flags().StringVar(&flags.schemaFile, schemaFileFlagName, "", "Server's schema as file or url (required)")
+	deprecationsCmd.Flags().StringArrayVar(&flags.schemaFiles, schemaFileFlagName, []string{}, "Server's schema as file or url. Can be repeated (required)")
 	deprecationsCmd.MarkFlagRequired(schemaFileFlagName) //nolint:errcheck // will err if flag doesn't exist
-
-	deprecationsCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore")
+	deprecationsCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore. Can be repeated")
 }
 
 func deprecationsCmdRun(cmd *cobra.Command, args []string) error {
-	schema, err := sources.LoadSchema(flags.schemaFile)
-	if err != nil {
-		return err
-	}
+	out := output.Data{}
 
-	queryFiles, err := input.ExpandGlobs(args, flags.ignore)
-	if err != nil {
-		return fmt.Errorf("Error: %s", err)
-	}
+	for _, schemaFile := range flags.schemaFiles {
+		schema, err := sources.LoadSchema(schemaFile)
+		if err != nil {
+			return err
+		}
 
-	queryFields, err := sources.LoadQueries(schema, queryFiles)
-	if err != nil {
-		return fmt.Errorf("Unable to parse files: %s", err)
+		queryFiles, err := input.ExpandGlobs(args, []string{})
+		if err != nil {
+			return fmt.Errorf("Error: %s", err)
+		}
+
+		queryFields, err := sources.LoadQueries(schema, queryFiles)
+		if err != nil {
+			return fmt.Errorf("Unable to parse files: %s", err)
+		}
+
+		for _, q := range queryFields {
+			f := output.Field{
+				Field:             q.Path,
+				File:              q.File,
+				Line:              q.Line,
+				DeprecationReason: q.DeprecationReason,
+			}
+			out.AppendField(schemaFile, f)
+		}
 	}
 
 	switch flags.outputFormat {
 	case stdoutFormat:
-		deprecationStdOut(queryFields)
+		deprecationStdOut(out)
 
 	case jsonFormat:
-		err = deprecationJsonOut(queryFields)
+		err := deprecationJsonOut(out)
 		if err != nil {
 			return err
 		}
 	case xcodeFormat:
-		deprecationXcodeOut(queryFields)
+		deprecationXcodeOut(out)
 	default:
 		return fmt.Errorf("%s is not a valid output format. Choose between json and stdout", flags.outputFormat)
 	}
@@ -64,27 +76,19 @@ func deprecationsCmdRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func deprecationStdOut(queryFields parser.QueryFieldList) {
-	for _, q := range queryFields {
-		fmt.Printf("%s is deprecated\n", q.Path)
-		fmt.Printf("  File:   %s:%d\n", q.File, q.Line)
-		fmt.Printf("  Reason: %s\n", q.DeprecationReason)
+func deprecationStdOut(out output.Data) {
+	out.Walk(func(schema string, f output.Field, i int) {
+		if i == 0 {
+			fmt.Println("Schema:", schema)
+		}
+		fmt.Printf("  %s is deprecated\n", f.Field)
+		fmt.Printf("    File:   %s:%d\n", f.File, f.Line)
+		fmt.Printf("    Reason: %s\n", f.DeprecationReason)
 		fmt.Println()
-	}
+	})
 }
 
-func deprecationJsonOut(queryFields parser.QueryFieldList) error {
-	out := output.Data{}
-
-	for _, q := range queryFields {
-		f := output.Field{
-			Field:             q.Path,
-			File:              q.File,
-			Line:              q.Line,
-			DeprecationReason: q.DeprecationReason,
-		}
-		out = append(out, f)
-	}
+func deprecationJsonOut(out output.Data) error {
 	bytes, err := json.Marshal(out)
 	if err != nil {
 		return fmt.Errorf("Failed to encode json: %s\n", err)
@@ -94,11 +98,11 @@ func deprecationJsonOut(queryFields parser.QueryFieldList) error {
 	return nil
 }
 
-func deprecationXcodeOut(queryFields parser.QueryFieldList) {
-	for _, q := range queryFields {
-		fmt.Printf("%s:%d: warning: ", q.File, q.Line)
-		fmt.Printf("%s is deprecated ", q.Path)
-		fmt.Printf("- Reason: %s", q.DeprecationReason)
+func deprecationXcodeOut(out output.Data) {
+	out.Walk(func(_ string, f output.Field, _ int) {
+		fmt.Printf("%s:%d: warning: ", f.File, f.Line)
+		fmt.Printf("%s is deprecated ", f.Field)
+		fmt.Printf("- Reason: %s", f.DeprecationReason)
 		fmt.Println()
-	}
+	})
 }

--- a/cmd/ops/deprecation.go
+++ b/cmd/ops/deprecation.go
@@ -37,7 +37,7 @@ func deprecationsCmdRun(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		queryFiles, err := input.ExpandGlobs(args, []string{})
+		queryFiles, err := input.ExpandGlobs(args, flags.ignore)
 		if err != nil {
 			return fmt.Errorf("Error: %s", err)
 		}

--- a/cmd/ops/diff.go
+++ b/cmd/ops/diff.go
@@ -29,7 +29,7 @@ func diffCmdRun(cmd *cobra.Command, args []string) error {
 
 	switch flags.outputFormat {
 	case stdoutFormat:
-		diffStdOut(fileA, fileB, result)
+		diffStdOut(result)
 	case jsonFormat:
 		err = diffJsonOut(result)
 		if err != nil {
@@ -44,7 +44,7 @@ func diffCmdRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func diffStdOut(_ string, _ string, out output.Data) {
+func diffStdOut(out output.Data) {
 	out.Walk(func(schema string, f output.Field, i int) {
 		if i == 0 {
 			fmt.Println("Schema: ", schema)

--- a/cmd/ops/diff.go
+++ b/cmd/ops/diff.go
@@ -44,15 +44,14 @@ func diffCmdRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func diffStdOut(_ string, fileB string, out output.Data) {
-	if len(out) == 0 {
-		return
-	}
-
-	for _, f := range out {
+func diffStdOut(_ string, _ string, out output.Data) {
+	out.Walk(func(schema string, f output.Field, i int) {
+		if i == 0 {
+			fmt.Println("Schema: ", schema)
+		}
 		fmt.Printf("%s (%s)\n", f.Field, f.DeprecationReason)
 		fmt.Printf("  %s:%d\n", f.File, f.Line)
-	}
+	})
 }
 
 func diffJsonOut(out output.Data) error {
@@ -66,10 +65,10 @@ func diffJsonOut(out output.Data) error {
 }
 
 func diffXcodeOut(out output.Data) {
-	for _, f := range out {
+	out.Walk(func(_ string, f output.Field, _ int) {
 		fmt.Printf("%s:%d: warning: ", f.File, f.Line)
 		fmt.Printf("%s is deprecated ", f.Field)
 		fmt.Printf("- Reason: %s", f.DeprecationReason)
 		fmt.Println()
-	}
+	})
 }

--- a/cmd/ops/flags_helpers.go
+++ b/cmd/ops/flags_helpers.go
@@ -14,10 +14,15 @@ const (
 var flags = struct {
 	outputFormat string
 	schemaFile   string
+	schemaFiles  []string
 	ignore       []string
 }{}
 
+// this is important for tests as these flags wont be reset between each test
+// run unless we do it here.
 func setFlagsToDefault() {
 	flags.outputFormat = stdoutFormat
 	flags.schemaFile = schemaFileDefault
+	flags.schemaFiles = []string{}
+	flags.ignore = []string{}
 }

--- a/cmd/testdata/deprecation.ct
+++ b/cmd/testdata/deprecation.ct
@@ -6,8 +6,8 @@ Usage:
 
 Flags:
   -h, --help                 help for deprecation
-      --ignore stringArray   Files to ignore
-      --schema string        Server's schema as file or url (required)
+      --ignore stringArray   Files to ignore. Can be repeated
+      --schema stringArray   Server's schema as file or url. Can be repeated (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -20,8 +20,8 @@ Usage:
 
 Flags:
   -h, --help                 help for deprecation
-      --ignore stringArray   Files to ignore
-      --schema string        Server's schema as file or url (required)
+      --ignore stringArray   Files to ignore. Can be repeated
+      --schema stringArray   Server's schema as file or url. Can be repeated (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -34,40 +34,36 @@ Usage:
 
 Flags:
   -h, --help                 help for deprecation
-      --ignore stringArray   Files to ignore
-      --schema string        Server's schema as file or url (required)
+      --ignore stringArray   Files to ignore. Can be repeated
+      --schema stringArray   Server's schema as file or url. Can be repeated (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
 
 # outputs deprecations to stdout if no `--output` is given
 $ gql-lint deprecation --schema testdata/schemas/with_deprecations.gql testdata/queries/author/*.gql
-author.books.title is deprecated
-  File:   testdata/queries/author/author.gql:7
-  Reason: untitled books are better
+Schema: testdata/schemas/with_deprecations.gql
+  author.books.title is deprecated
+    File:   testdata/queries/author/author.gql:7
+    Reason: untitled books are better
 
 # fails with exit code 10 if it couldn't download the schema
-$ gql-lint deprecation --schema http://localhost:9999/schema_does_not_exists testdata/queries/author --> FAIL 10
-Error: failed to download schema: Post "http://localhost:9999/schema_does_not_exists": dial tcp [::1]:9999: connect: connection refused
+$ gql-lint deprecation --schema http://127.0.0.1:9999/schema_does_not_exists testdata/queries/author --> FAIL 10
+Error: failed to download schema: Post "http://127.0.0.1:9999/schema_does_not_exists": dial tcp 127.0.0.1:9999: connect: connection refused
 Usage:
   gql-lint deprecation [flags] queries
 
 Flags:
   -h, --help                 help for deprecation
-      --ignore stringArray   Files to ignore
-      --schema string        Server's schema as file or url (required)
+      --ignore stringArray   Files to ignore. Can be repeated
+      --schema stringArray   Server's schema as file or url. Can be repeated (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
 
-# outputs deprecations as json
-$ gql-lint deprecation --output json --schema testdata/schemas/with_deprecations.gql testdata/queries/author/*.gql
-[{"field":"author.books.title","file":"testdata/queries/author/author.gql","line":7,"reason":"untitled books are better"}]
-
-# ignores a given file glob
-$ gql-lint deprecation --output json --schema testdata/schemas/with_deprecations.gql --ignore testdata/queries/author/author_id.gql testdata/queries/author/*.gql
-[{"field":"author.books.title","file":"testdata/queries/author/author.gql","line":7,"reason":"untitled books are better"}]
-
-# outputs deprecations as xcode
-$ gql-lint deprecation --output xcode --schema testdata/schemas/with_deprecations.gql  testdata/queries/author/*.gql
-testdata/queries/author/author.gql:7: warning: author.books.title is deprecated - Reason: untitled books are better
+# supports repeated --schema
+$ gql-lint deprecation --schema testdata/schemas/with_deprecations.gql --schema testdata/schemas/album.gql testdata/queries/author/*.gql
+Schema: testdata/schemas/with_deprecations.gql
+  author.books.title is deprecated
+    File:   testdata/queries/author/author.gql:7
+    Reason: untitled books are better

--- a/cmd/testdata/deprecation.ct
+++ b/cmd/testdata/deprecation.ct
@@ -67,3 +67,15 @@ Schema: testdata/schemas/with_deprecations.gql
   author.books.title is deprecated
     File:   testdata/queries/author/author.gql:7
     Reason: untitled books are better
+
+# outputs deprecations as json
+$ gql-lint deprecation --output json --schema testdata/schemas/with_deprecations.gql testdata/queries/author/*.gql
+{"testdata/schemas/with_deprecations.gql":[{"field":"author.books.title","file":"testdata/queries/author/author.gql","line":7,"reason":"untitled books are better"}]}
+
+# ignores a given file glob
+$ gql-lint deprecation --output json --schema testdata/schemas/with_deprecations.gql --ignore testdata/queries/author/author_id.gql testdata/queries/author/*.gql
+{"testdata/schemas/with_deprecations.gql":[{"field":"author.books.title","file":"testdata/queries/author/author.gql","line":7,"reason":"untitled books are better"}]}
+
+# outputs deprecations as xcode
+$ gql-lint deprecation --output xcode --schema testdata/schemas/with_deprecations.gql  testdata/queries/author/*.gql
+testdata/queries/author/author.gql:7: warning: author.books.title is deprecated - Reason: untitled books are better

--- a/cmd/testdata/diff.ct
+++ b/cmd/testdata/diff.ct
@@ -36,13 +36,17 @@ Global Flags:
 
 # outputs diff to stdout if no `--output` is given
 $ gql-lint diff testdata/json/a.json testdata/json/b.json
+Schema:  b.json
+Article.isPublic (Please migrate to publicAccessLevel)
+  somefile.graphql:7
 Article.view (Please migrate to Article.permissions)
   somefile.graphql:13
 
 # outputs diff as json
 $ gql-lint diff --output json testdata/json/a.json testdata/json/b.json
-[{"field":"Article.view","file":"somefile.graphql","line":13,"reason":"Please migrate to Article.permissions"}]
+{"b.json":[{"field":"Article.isPublic","file":"somefile.graphql","line":7,"reason":"Please migrate to publicAccessLevel"},{"field":"Article.view","file":"somefile.graphql","line":13,"reason":"Please migrate to Article.permissions"}]}
 
 # outputs diff as xcode
 $ gql-lint diff --output xcode testdata/json/a.json testdata/json/b.json
+somefile.graphql:7: warning: Article.isPublic is deprecated - Reason: Please migrate to publicAccessLevel
 somefile.graphql:13: warning: Article.view is deprecated - Reason: Please migrate to Article.permissions

--- a/cmd/testdata/json/a.json
+++ b/cmd/testdata/json/a.json
@@ -1,8 +1,10 @@
-[
-    {
-        "field": "Article.isPublic",
-        "file": "somefile.graphql",
-        "line": 7,
-        "reason": "Please migrate to publicAccessLevel"
-    }
-]
+{
+    "a.json": [
+        {
+            "field": "Article.isPublic",
+            "file": "somefile.graphql",
+            "line": 7,
+            "reason": "Please migrate to publicAccessLevel"
+        }
+    ]
+}

--- a/cmd/testdata/json/b.json
+++ b/cmd/testdata/json/b.json
@@ -1,14 +1,16 @@
-[
-    {
-        "field": "Article.isPublic",
-        "file": "somefile.graphql",
-        "line": 7,
-        "reason": "Please migrate to publicAccessLevel"
-    },
-    {
-        "field": "Article.view",
-        "file": "somefile.graphql",
-        "line": 13,
-        "reason": "Please migrate to Article.permissions"
-    }
-]
+{
+    "b.json": [
+        {
+            "field": "Article.isPublic",
+            "file": "somefile.graphql",
+            "line": 7,
+            "reason": "Please migrate to publicAccessLevel"
+        },
+        {
+            "field": "Article.view",
+            "file": "somefile.graphql",
+            "line": 13,
+            "reason": "Please migrate to Article.permissions"
+        }
+    ]
+}

--- a/cmd/testdata/schemas/album.gql
+++ b/cmd/testdata/schemas/album.gql
@@ -1,0 +1,4 @@
+type Album {
+  id: Int!
+  name: String!
+}

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -42,14 +42,14 @@ func TestCompareFiles(t *testing.T) {
 				fileA: "testdata/a.json",
 				fileB: "testdata/b.json",
 			},
-			want: output.Data{
-				output.Field{
+			want: output.Data{"http://example.com/schema": []output.Field{
+				{
 					Field:             "Article.view",
 					File:              "somefile.graphql",
 					Line:              13,
 					DeprecationReason: "Please migrate to Article.permissions",
 				},
-			},
+			}},
 			wantErr: false,
 		},
 		{

--- a/output/testdata/a.json
+++ b/output/testdata/a.json
@@ -1,8 +1,10 @@
-[
-    {
-        "field": "Article.isPublic",
-        "file": "somefile.graphql",
-        "line": 7,
-        "reason": "Please migrate to publicAccessLevel"
-    }
-]
+{
+    "http://example.com/schema": [
+        {
+            "field": "Article.isPublic",
+            "file": "somefile.graphql",
+            "line": 7,
+            "reason": "Please migrate to publicAccessLevel"
+        }
+    ]
+}

--- a/output/testdata/b.json
+++ b/output/testdata/b.json
@@ -1,14 +1,16 @@
-[
-    {
-        "field": "Article.isPublic",
-        "file": "somefile.graphql",
-        "line": 7,
-        "reason": "Please migrate to publicAccessLevel"
-    },
-    {
-        "field": "Article.view",
-        "file": "somefile.graphql",
-        "line": 13,
-        "reason": "Please migrate to Article.permissions"
-    }
-]
+{
+    "http://example.com/schema": [
+        {
+            "field": "Article.isPublic",
+            "file": "somefile.graphql",
+            "line": 7,
+            "reason": "Please migrate to publicAccessLevel"
+        },
+        {
+            "field": "Article.view",
+            "file": "somefile.graphql",
+            "line": 13,
+            "reason": "Please migrate to Article.permissions"
+        }
+    ]
+}

--- a/output/testdata/parse_error.json
+++ b/output/testdata/parse_error.json
@@ -1,8 +1,16 @@
-[
-    {
-        "field": "Article.isPublic",
-        "file": "somefile.graphql",
-        "line": 7,
-        "reason": "Please migrate to publicAccessLevel"
-    },
-]
+{
+    "b.json": [
+        {
+            "field": "Article.isPublic",
+            "file": "somefile.graphql",
+            "line": 7,
+            "reason": "Please migrate to publicAccessLevel"
+        },
+        {
+            "field": "Article.view",
+            "file": "somefile.graphql",
+            "line": 13,
+            "reason": "Please migrate to Article.permissions"
+        },
+    ]
+}


### PR DESCRIPTION
Makes implementing GH actions easier by not having to invoke the tools multiple times, once for each service and then having to combine outputs, etc.

Also contains a small improvement where you can regenerate the cmdtest files without having to change the flag in the test file. It's very easy to forget to reset the flag. Now it's possible to do via the `UPDATE_CMD_TESTS=true` env variable when running tests.

To keep this PR small-ish I will add support for multiple `--schema` for the `unused` command in a follow up PR. 