### PR TITLE
Query file globs are processed twice

### DIFF
--- a/cmd/ops/deprecation.go
+++ b/cmd/ops/deprecation.go
@@ -31,15 +31,15 @@ func init() {
 func deprecationsCmdRun(cmd *cobra.Command, args []string) error {
 	out := output.Data{}
 
+	queryFiles, err := input.ExpandGlobs(args, flags.ignore)
+	if err != nil {
+		return fmt.Errorf("Error: %s", err)
+	}
+
 	for _, schemaFile := range flags.schemaFiles {
 		schema, err := sources.LoadSchema(schemaFile)
 		if err != nil {
 			return err
-		}
-
-		queryFiles, err := input.ExpandGlobs(args, flags.ignore)
-		if err != nil {
-			return fmt.Errorf("Error: %s", err)
 		}
 
 		queryFields, err := sources.LoadQueries(schema, queryFiles)


### PR DESCRIPTION
No need to process query file globs more than once.