### PR TITLE
`--verbose` flag added.

### DIFF
--- a/cmd/ops/deprecation.go
+++ b/cmd/ops/deprecation.go
@@ -26,6 +26,7 @@ func init() {
 	deprecationsCmd.Flags().StringArrayVar(&flags.schemaFiles, schemaFileFlagName, []string{}, "Server's schema as file or url. Can be repeated (required)")
 	deprecationsCmd.MarkFlagRequired(schemaFileFlagName) //nolint:errcheck // will err if flag doesn't exist
 	deprecationsCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore. Can be repeated")
+	deprecationsCmd.Flags().BoolVarP(&flags.verbose, verboseFlagName, "v", false, "Verbose mode. Will print debug messages")
 }
 
 func deprecationsCmdRun(cmd *cobra.Command, args []string) error {
@@ -36,10 +37,21 @@ func deprecationsCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Error: %s", err)
 	}
 
+	if flags.verbose {
+		fmt.Println("debug: Processing the following query files:")
+		for _, file := range queryFiles {
+			fmt.Println("  -", file)
+		}
+	}
+
 	for _, schemaFile := range flags.schemaFiles {
 		schema, err := sources.LoadSchema(schemaFile)
 		if err != nil {
 			return err
+		}
+
+		if flags.verbose {
+			fmt.Println("debug: Succesfully loaded schema from", schemaFile)
 		}
 
 		queryFields, err := sources.LoadQueries(schema, queryFiles)

--- a/cmd/ops/flags_helpers.go
+++ b/cmd/ops/flags_helpers.go
@@ -9,6 +9,7 @@ const (
 	markdownFormat       = "markdown"
 	xcodeFormat          = "xcode"
 	ignoreFlagName       = "ignore"
+	verboseFlagName      = "verbose"
 )
 
 var flags = struct {
@@ -16,6 +17,7 @@ var flags = struct {
 	schemaFile   string
 	schemaFiles  []string
 	ignore       []string
+	verbose      bool
 }{}
 
 // this is important for tests as these flags wont be reset between each test
@@ -25,4 +27,5 @@ func setFlagsToDefault() {
 	flags.schemaFile = schemaFileDefault
 	flags.schemaFiles = []string{}
 	flags.ignore = []string{}
+	flags.verbose = false
 }

--- a/cmd/testdata/deprecation.ct
+++ b/cmd/testdata/deprecation.ct
@@ -8,6 +8,7 @@ Flags:
   -h, --help                 help for deprecation
       --ignore stringArray   Files to ignore. Can be repeated
       --schema stringArray   Server's schema as file or url. Can be repeated (required)
+  -v, --verbose              Verbose mode. Will print debug messages
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -22,6 +23,7 @@ Flags:
   -h, --help                 help for deprecation
       --ignore stringArray   Files to ignore. Can be repeated
       --schema stringArray   Server's schema as file or url. Can be repeated (required)
+  -v, --verbose              Verbose mode. Will print debug messages
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -36,6 +38,7 @@ Flags:
   -h, --help                 help for deprecation
       --ignore stringArray   Files to ignore. Can be repeated
       --schema stringArray   Server's schema as file or url. Can be repeated (required)
+  -v, --verbose              Verbose mode. Will print debug messages
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -57,6 +60,7 @@ Flags:
   -h, --help                 help for deprecation
       --ignore stringArray   Files to ignore. Can be repeated
       --schema stringArray   Server's schema as file or url. Can be repeated (required)
+  -v, --verbose              Verbose mode. Will print debug messages
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -79,3 +83,25 @@ $ gql-lint deprecation --output json --schema testdata/schemas/with_deprecations
 # outputs deprecations as xcode
 $ gql-lint deprecation --output xcode --schema testdata/schemas/with_deprecations.gql  testdata/queries/author/*.gql
 testdata/queries/author/author.gql:7: warning: author.books.title is deprecated - Reason: untitled books are better
+
+# outputs debug info if --verbose is used
+$ gql-lint deprecation --verbose --schema testdata/schemas/with_deprecations.gql testdata/queries/author/*.gql
+debug: Processing the following query files:
+  - testdata/queries/author/author.gql
+  - testdata/queries/author/author_id.gql
+debug: Succesfully loaded schema from testdata/schemas/with_deprecations.gql
+Schema: testdata/schemas/with_deprecations.gql
+  author.books.title is deprecated
+    File:   testdata/queries/author/author.gql:7
+    Reason: untitled books are better
+
+# outputs debug info if -v is used
+$ gql-lint deprecation --verbose --schema testdata/schemas/with_deprecations.gql testdata/queries/author/*.gql
+debug: Processing the following query files:
+  - testdata/queries/author/author.gql
+  - testdata/queries/author/author_id.gql
+debug: Succesfully loaded schema from testdata/schemas/with_deprecations.gql
+Schema: testdata/schemas/with_deprecations.gql
+  author.books.title is deprecated
+    File:   testdata/queries/author/author.gql:7
+    Reason: untitled books are better

--- a/cmd/testdata/unused.ct
+++ b/cmd/testdata/unused.ct
@@ -8,6 +8,7 @@ Flags:
   -h, --help                 help for unused
       --ignore stringArray   Files to ignore
       --schema string        Server's schema as file or url (required)
+  -v, --verbose              Verbose mode. Will print debug messages
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -22,6 +23,7 @@ Flags:
   -h, --help                 help for unused
       --ignore stringArray   Files to ignore
       --schema string        Server's schema as file or url (required)
+  -v, --verbose              Verbose mode. Will print debug messages
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -36,6 +38,7 @@ Flags:
   -h, --help                 help for unused
       --ignore stringArray   Files to ignore
       --schema string        Server's schema as file or url (required)
+  -v, --verbose              Verbose mode. Will print debug messages
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -63,3 +66,17 @@ $ gql-lint unused --output json --schema testdata/schemas/with_deprecations.gql 
 # outputs for slack
 $ gql-lint unused --output markdown --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql
 - Book.title
+
+# outputs debug info if --verbose is used
+$ gql-lint unused --verbose --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql
+debug: Processing the following query files:
+  - testdata/queries/unused/without_title/without_title.gql
+debug: Succesfully loaded schema from testdata/schemas/with_deprecations.gql
+`Book.title` is unused and can be removed
+
+# outputs debug info if -v is used
+$ gql-lint unused -v --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql
+debug: Processing the following query files:
+  - testdata/queries/unused/without_title/without_title.gql
+debug: Succesfully loaded schema from testdata/schemas/with_deprecations.gql
+`Book.title` is unused and can be removed


### PR DESCRIPTION
This PR adds basic debug info if `--verbose` or `-v` is provided. While working on the GH actions this came up many times. Especially when working with glob patterns for loading query files.