### PR TITLE
Multiple `--schema` support added for `unused` command

### DIFF
--- a/cmd/ops/deprecation.go
+++ b/cmd/ops/deprecation.go
@@ -29,8 +29,6 @@ func init() {
 }
 
 func deprecationsCmdRun(cmd *cobra.Command, args []string) error {
-	out := output.Data{}
-
 	queryFiles, err := input.ExpandGlobs(args, flags.ignore)
 	if err != nil {
 		return fmt.Errorf("Error: %s", err)
@@ -43,6 +41,7 @@ func deprecationsCmdRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	out := output.Data{}
 	for _, schemaFile := range flags.schemaFiles {
 		schema, err := sources.LoadSchema(schemaFile)
 		if err != nil {

--- a/cmd/ops/deprecation.go
+++ b/cmd/ops/deprecation.go
@@ -26,7 +26,6 @@ func init() {
 	deprecationsCmd.Flags().StringArrayVar(&flags.schemaFiles, schemaFileFlagName, []string{}, "Server's schema as file or url. Can be repeated (required)")
 	deprecationsCmd.MarkFlagRequired(schemaFileFlagName) //nolint:errcheck // will err if flag doesn't exist
 	deprecationsCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore. Can be repeated")
-	deprecationsCmd.Flags().BoolVarP(&flags.verbose, verboseFlagName, "v", false, "Verbose mode. Will print debug messages")
 }
 
 func deprecationsCmdRun(cmd *cobra.Command, args []string) error {

--- a/cmd/ops/deprecation.go
+++ b/cmd/ops/deprecation.go
@@ -26,6 +26,7 @@ func init() {
 	deprecationsCmd.Flags().StringArrayVar(&flags.schemaFiles, schemaFileFlagName, []string{}, "Server's schema as file or url. Can be repeated (required)")
 	deprecationsCmd.MarkFlagRequired(schemaFileFlagName) //nolint:errcheck // will err if flag doesn't exist
 	deprecationsCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore. Can be repeated")
+	deprecationsCmd.Flags().BoolVarP(&flags.verbose, verboseFlagName, "v", false, "Verbose mode. Will print debug messages")
 }
 
 func deprecationsCmdRun(cmd *cobra.Command, args []string) error {

--- a/cmd/ops/flags_helpers.go
+++ b/cmd/ops/flags_helpers.go
@@ -2,7 +2,6 @@ package ops
 
 const (
 	schemaFileFlagName   = "schema"
-	schemaFileDefault    = ""
 	outputFormatFlagName = "output"
 	jsonFormat           = "json"
 	stdoutFormat         = "stdout"
@@ -14,7 +13,6 @@ const (
 
 var flags = struct {
 	outputFormat string
-	schemaFile   string
 	schemaFiles  []string
 	ignore       []string
 	verbose      bool
@@ -24,7 +22,6 @@ var flags = struct {
 // run unless we do it here.
 func setFlagsToDefault() {
 	flags.outputFormat = stdoutFormat
-	flags.schemaFile = schemaFileDefault
 	flags.schemaFiles = []string{}
 	flags.ignore = []string{}
 	flags.verbose = false

--- a/cmd/ops/unused.go
+++ b/cmd/ops/unused.go
@@ -31,6 +31,7 @@ func init() {
 	unusedCmd.MarkFlagRequired(schemaFileFlagName) //nolint:errcheck // will err if flag doesn't exist
 
 	unusedCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore")
+	unusedCmd.Flags().BoolVarP(&flags.verbose, verboseFlagName, "v", false, "Verbose mode. Will print debug messages")
 }
 
 func unusedCmdRun(cmd *cobra.Command, args []string) error {

--- a/cmd/ops/unused.go
+++ b/cmd/ops/unused.go
@@ -31,7 +31,6 @@ func init() {
 	unusedCmd.MarkFlagRequired(schemaFileFlagName) //nolint:errcheck // will err if flag doesn't exist
 
 	unusedCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore")
-	unusedCmd.Flags().BoolVarP(&flags.verbose, verboseFlagName, "v", false, "Verbose mode. Will print debug messages")
 }
 
 func unusedCmdRun(cmd *cobra.Command, args []string) error {

--- a/cmd/testdata/unused.ct
+++ b/cmd/testdata/unused.ct
@@ -7,7 +7,7 @@ Usage:
 Flags:
   -h, --help                 help for unused
       --ignore stringArray   Files to ignore
-      --schema string        Server's schema as file or url (required)
+      --schema stringArray   Server's schema as file or url. Can be repeated (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -22,7 +22,7 @@ Usage:
 Flags:
   -h, --help                 help for unused
       --ignore stringArray   Files to ignore
-      --schema string        Server's schema as file or url (required)
+      --schema stringArray   Server's schema as file or url. Can be repeated (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -37,7 +37,7 @@ Usage:
 Flags:
   -h, --help                 help for unused
       --ignore stringArray   Files to ignore
-      --schema string        Server's schema as file or url (required)
+      --schema stringArray   Server's schema as file or url. Can be repeated (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -45,38 +45,46 @@ Global Flags:
 
 # outputs unused deprecated fields to stdout if no `--output` is given
 $ gql-lint unused --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql
-`Book.title` is unused and can be removed
+Schema: testdata/schemas/with_deprecations.gql
+  Book.title (line 1) is unused and can be removed
+
+# supports repeated --schema
+$ gql-lint unused --schema testdata/schemas/with_deprecations.gql --schema testdata/schemas/album.gql testdata/queries/unused/without_title/*.gql
+Schema: testdata/schemas/with_deprecations.gql
+  Book.title (line 1) is unused and can be removed
 
 # outputs deprecations as json
 $ gql-lint unused --output json --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql
-[{"field":"Book.title"}]
+{"testdata/schemas/with_deprecations.gql":[{"field":"Book.title","file":"","line":1,"reason":""}]}
 
 # ignores a given file blob
 $ gql-lint unused --output json --schema testdata/schemas/with_deprecations.gql --ignore testdata/queries/unused/without_title/*.gql testdata/queries/unused/**/*.gql
-[]
+{"testdata/schemas/with_deprecations.gql":[]}
 
-# outputs success message if no unused fields are found
+# outputs nothing if no unused fields are found
 $ gql-lint unused --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/with_title/with_title.gql testdata/queries/unused/without_title/without_title.gql
-Nothing can be removed right now
 
 # outputs empty json if no unused fields are found
 $ gql-lint unused --output json --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/with_title/with_title.gql testdata/queries/unused/without_title/without_title.gql
-[]
+{"testdata/schemas/with_deprecations.gql":[]}
 
 # outputs for slack
 $ gql-lint unused --output markdown --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql
-- Book.title
+** testdata/schemas/with_deprecations.gql **
+- Book.title (line `1`)
 
 # outputs debug info if --verbose is used
 $ gql-lint --verbose unused --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql
 debug: Processing the following query files:
   - testdata/queries/unused/without_title/without_title.gql
 debug: Succesfully loaded schema from testdata/schemas/with_deprecations.gql
-`Book.title` is unused and can be removed
+Schema: testdata/schemas/with_deprecations.gql
+  Book.title (line 1) is unused and can be removed
 
 # outputs debug info if -v is used
 $ gql-lint -v unused --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql
 debug: Processing the following query files:
   - testdata/queries/unused/without_title/without_title.gql
 debug: Succesfully loaded schema from testdata/schemas/with_deprecations.gql
-`Book.title` is unused and can be removed
+Schema: testdata/schemas/with_deprecations.gql
+  Book.title (line 1) is unused and can be removed

--- a/output/output.go
+++ b/output/output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 )
 
 type Field struct {
@@ -18,6 +19,14 @@ func (f *Field) Equals(b *Field) bool {
 }
 
 type Data map[string][]Field
+
+func (d Data) SortByField() {
+	for schema := range d {
+		sort.Slice(d[schema], func(i, j int) bool {
+			return d[schema][i].Field < d[schema][j].Field
+		})
+	}
+}
 
 type DataWalkFunc func(schema string, field Field, fieldIdx int)
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -10,6 +10,7 @@ import (
 
 type SchemaField struct {
 	Name string
+	Line int
 }
 
 type QueryField struct {
@@ -57,12 +58,18 @@ func ParseDeprecatedFields(schema *ast.Schema) []SchemaField {
 		}
 
 		if ok, _ := isDeprecated(definition.Directives); ok {
-			fields = append(fields, SchemaField{Name: name})
+			fields = append(fields, SchemaField{
+				Name: name,
+				Line: definition.Position.Line,
+			})
 		}
 
 		for _, field := range definition.Fields {
 			if ok, _ := isDeprecated(field.Directives); ok {
-				fields = append(fields, SchemaField{Name: fmt.Sprintf("%s.%s", name, field.Name)})
+				fields = append(fields, SchemaField{
+					Name: fmt.Sprintf("%s.%s", name, field.Name),
+					Line: definition.Position.Line,
+				})
 			}
 		}
 	}

--- a/unused/unused_test.go
+++ b/unused/unused_test.go
@@ -1,40 +1,39 @@
-package unused
+package unused_test
 
 import (
 	"testing"
 
 	"github.com/matryer/is"
-	"github.com/sketch-hq/gql-lint/sources"
+	"github.com/sketch-hq/gql-lint/unused"
 )
 
 func TestGetUnusedFields(t *testing.T) {
 	is := is.New(t)
 
-	schema, err := sources.LoadSchema("testdata/schemas/with_deprecations.gql")
-	is.NoErr(err)
+	schema := "testdata/schemas/with_deprecations.gql"
 
 	t.Run("reports unused fields", func(t *testing.T) {
 		is := is.New(t)
-		unusedFields, err := GetUnusedFields(schema, []string{
+		unusedFields, err := unused.GetUnusedFields([]string{schema}, []string{
 			"testdata/queries/one/one.gql",
 			"testdata/queries/deprecation/deprecation.gql",
-		})
+		}, false)
 		is.NoErr(err)
 
 		is.Equal(len(unusedFields), 1)
-		is.Equal(unusedFields[0].Name, "Book.oldTitle")
+		is.Equal(unusedFields[schema][0].Field, "Book.oldTitle")
 	})
 
 	t.Run("sorts fields aphabetically", func(t *testing.T) {
 		is := is.New(t)
-		unusedFields, err := GetUnusedFields(schema, []string{
+		unusedFields, err := unused.GetUnusedFields([]string{schema}, []string{
 			"testdata/queries/one/one.gql",
-		})
+		}, false)
 		is.NoErr(err)
 
-		is.Equal(len(unusedFields), 2)
+		is.Equal(len(unusedFields[schema]), 2)
 
-		is.Equal(unusedFields[0].Name, "Book.oldTitle")
-		is.Equal(unusedFields[1].Name, "Book.title")
+		is.Equal(unusedFields[schema][0].Field, "Book.oldTitle")
+		is.Equal(unusedFields[schema][1].Field, "Book.title")
 	})
 }


### PR DESCRIPTION
This PR adds support for specifying and checking multiple schemas for unused deprecated fields. This is similar to what was added for `deprecation` in https://github.com/sketch-hq/gql-lint/pull/23.

It also includes the line number where the field was found in the schema as well as the name of the schema in any output.