### PR TITLE
Tweak markdown output for `unused`

### DIFF
--- a/cmd/ops/unused.go
+++ b/cmd/ops/unused.go
@@ -96,7 +96,7 @@ func unusedMarkdownOut(out output.Data) {
 	out.Walk(func(schema string, f output.Field, fieldIdx int) {
 		if fieldIdx == 0 {
 			if hasUnused {
-				fmt.Printf("\n") // new line for each schema
+				fmt.Printf("\n") // new line for each schema, except the first one.
 			}
 			hasUnused = true
 			fmt.Println("Schema:", schema)

--- a/cmd/ops/unused.go
+++ b/cmd/ops/unused.go
@@ -95,8 +95,11 @@ func unusedMarkdownOut(out output.Data) {
 
 	out.Walk(func(schema string, f output.Field, fieldIdx int) {
 		if fieldIdx == 0 {
+			if hasUnused {
+				fmt.Printf("\n") // new line for each schema
+			}
 			hasUnused = true
-			fmt.Println("**", schema, "**")
+			fmt.Println("Schema:", schema)
 		}
 		fmt.Printf("- %s (line `%d`)\n", f.Field, f.Line)
 	})

--- a/cmd/testdata/queries/unused/album.gql
+++ b/cmd/testdata/queries/unused/album.gql
@@ -1,0 +1,8 @@
+query {
+  author(id: 123) {
+    id
+    name
+    title
+  }
+}
+

--- a/cmd/testdata/schemas/album.gql
+++ b/cmd/testdata/schemas/album.gql
@@ -1,4 +1,5 @@
 type Album {
   id: Int!
   name: String!
+  title: String! @deprecated(reason: "use name instead")
 }

--- a/cmd/testdata/unused.ct
+++ b/cmd/testdata/unused.ct
@@ -51,7 +51,10 @@ Schema: testdata/schemas/with_deprecations.gql
 # supports repeated --schema
 $ gql-lint unused --schema testdata/schemas/with_deprecations.gql --schema testdata/schemas/album.gql testdata/queries/unused/without_title/*.gql
 Schema: testdata/schemas/with_deprecations.gql
-  Book.title (line 1) is unused and can be removed
+  Book.title (line 1) is unused and can be removed 
+
+Schema: testdata/schemas/album.gql
+  Album.title (line 1) is unused and can be removed
 
 # outputs deprecations as json
 $ gql-lint unused --output json --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql
@@ -69,9 +72,12 @@ $ gql-lint unused --output json --schema testdata/schemas/with_deprecations.gql 
 {"testdata/schemas/with_deprecations.gql":[]}
 
 # outputs for slack
-$ gql-lint unused --output markdown --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql
-** testdata/schemas/with_deprecations.gql **
+$ gql-lint unused --output markdown --schema testdata/schemas/with_deprecations.gql --schema testdata/schemas/album.gql testdata/queries/unused/without_title/*.gql
+Schema: testdata/schemas/with_deprecations.gql
 - Book.title (line `1`)
+
+Schema: testdata/schemas/album.gql
+- Album.title (line `1`)
 
 # outputs debug info if --verbose is used
 $ gql-lint --verbose unused --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql


### PR DESCRIPTION
Keep the output simple (no bold) and just a space between each schema.