### PR TITLE
Support installing the latest version.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,9 @@ jobs:
     runs-on: macos-12
     needs: releases-matrix
     env:
-      ARM_FILE: "gql-lint-${{ github.ref_name }}-darwin-arm64.tar.gz"
-      INTEL_FILE: "gql-lint-${{ github.ref_name }}-darwin-amd64.tar.gz"
-      UNIVERSAL_FILE: "gql-lint-${{ github.ref_name }}-darwin-universal.tar.gz"
+      ARM_FILE: "gql-lint-darwin-arm64.tar.gz"
+      INTEL_FILE: "gql-lint-darwin-amd64.tar.gz"
+      UNIVERSAL_FILE: "gql-lint-darwin-universal.tar.gz"
     steps:
       - name: Print used variables
         run: |

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e
 
 VERSION=$1
@@ -19,16 +20,19 @@ else
   PLATFORM="linux"
 fi
 
-
-TARNAME=gql-lint-$VERSION-$PLATFORM-$ARCH.tar.gz
+# Stay backwards compatible with older versions that had the version in the file name.
+if [[ "v1v2v3" == *"$VERSION"* ]]; then
+  TARNAME=gql-lint-$VERSION-$PLATFORM-$ARCH.tar.gz
+else
+  TARNAME=gql-lint-$PLATFORM-$ARCH.tar.gz
+fi
+URL="https://github.com/sketch-hq/gql-lint/releases/download/$VERSION/$TARNAME"
 
 echo Downloading version $VERSION for $PLATFORM-$ARCH
-echo https://github.com/sketch-hq/gql-lint/releases/download/$VERSION/$TARNAME
+echo $URL
 echo ---
 
-
-
-curl -SLJO https://github.com/sketch-hq/gql-lint/releases/download/$VERSION/$TARNAME
+curl -SLJO $URL
 
 echo ---
 echo Installing


### PR DESCRIPTION
Drops the version from the filename to make it easier to download without having to figure out the filename. Stays backwards compatible with v1-v3 so we don't break any existing github actions.