### PR TITLE
Support for `--include` that works the opposite as `--ignore`

### DIFF
--- a/cmd/ops/deprecation.go
+++ b/cmd/ops/deprecation.go
@@ -23,13 +23,14 @@ The "queries" argument is a file glob matching one or more graphql query or muta
 
 func init() {
 	Program.AddCommand(deprecationsCmd)
-	deprecationsCmd.Flags().StringArrayVar(&flags.schemaFiles, schemaFileFlagName, []string{}, "Server's schema as file or url. Can be repeated (required)")
+	deprecationsCmd.Flags().StringSliceVar(&flags.schemaFiles, schemaFileFlagName, []string{}, "Server's schema as file or url (required)")
 	deprecationsCmd.MarkFlagRequired(schemaFileFlagName) //nolint:errcheck // will err if flag doesn't exist
-	deprecationsCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore. Can be repeated")
+	deprecationsCmd.Flags().StringSliceVar(&flags.include, includeFlagName, []string{}, "Only include files matching this pattern")
+	deprecationsCmd.Flags().StringSliceVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore")
 }
 
 func deprecationsCmdRun(cmd *cobra.Command, args []string) error {
-	queryFiles, err := input.ExpandGlobs(args, flags.ignore)
+	queryFiles, err := input.ExpandGlobs(args, flags.include, flags.ignore)
 	if err != nil {
 		return fmt.Errorf("Error: %s", err)
 	}

--- a/cmd/ops/flags_helpers.go
+++ b/cmd/ops/flags_helpers.go
@@ -9,6 +9,7 @@ const (
 	xcodeFormat          = "xcode"
 	annotateFormat       = "annotate"
 	ignoreFlagName       = "ignore"
+	includeFlagName      = "include"
 	verboseFlagName      = "verbose"
 )
 
@@ -16,6 +17,7 @@ var flags = struct {
 	outputFormat string
 	schemaFiles  []string
 	ignore       []string
+	include      []string
 	verbose      bool
 }{}
 
@@ -25,5 +27,6 @@ func setFlagsToDefault() {
 	flags.outputFormat = stdoutFormat
 	flags.schemaFiles = []string{}
 	flags.ignore = []string{}
+	flags.include = []string{}
 	flags.verbose = false
 }

--- a/cmd/ops/unused.go
+++ b/cmd/ops/unused.go
@@ -26,14 +26,14 @@ The "queries" argument is a file glob matching one or more graphql query or muta
 
 func init() {
 	Program.AddCommand(unusedCmd)
-	unusedCmd.Flags().StringArrayVar(&flags.schemaFiles, schemaFileFlagName, []string{}, "Server's schema as file or url. Can be repeated (required)")
+	unusedCmd.Flags().StringSliceVar(&flags.schemaFiles, schemaFileFlagName, []string{}, "Server's schema as file or url (required)")
 	unusedCmd.MarkFlagRequired(schemaFileFlagName) //nolint:errcheck // will err if flag doesn't exist
-
-	unusedCmd.Flags().StringArrayVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore")
+	unusedCmd.Flags().StringSliceVar(&flags.include, includeFlagName, []string{}, "Only include files matching this pattern")
+	unusedCmd.Flags().StringSliceVar(&flags.ignore, ignoreFlagName, []string{}, "Files to ignore")
 }
 
 func unusedCmdRun(cmd *cobra.Command, args []string) error {
-	queryFiles, err := input.ExpandGlobs(args, flags.ignore)
+	queryFiles, err := input.ExpandGlobs(args, flags.include, flags.ignore)
 	if err != nil {
 		return err
 	}

--- a/cmd/testdata/deprecation.ct
+++ b/cmd/testdata/deprecation.ct
@@ -5,9 +5,10 @@ Usage:
   gql-lint deprecation [flags] queries
 
 Flags:
-  -h, --help                 help for deprecation
-      --ignore stringArray   Files to ignore. Can be repeated
-      --schema stringArray   Server's schema as file or url. Can be repeated (required)
+  -h, --help              help for deprecation
+      --ignore strings    Files to ignore
+      --include strings   Only include files matching this pattern
+      --schema strings    Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -20,9 +21,10 @@ Usage:
   gql-lint deprecation [flags] queries
 
 Flags:
-  -h, --help                 help for deprecation
-      --ignore stringArray   Files to ignore. Can be repeated
-      --schema stringArray   Server's schema as file or url. Can be repeated (required)
+  -h, --help              help for deprecation
+      --ignore strings    Files to ignore
+      --include strings   Only include files matching this pattern
+      --schema strings    Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -35,9 +37,10 @@ Usage:
   gql-lint deprecation [flags] queries
 
 Flags:
-  -h, --help                 help for deprecation
-      --ignore stringArray   Files to ignore. Can be repeated
-      --schema stringArray   Server's schema as file or url. Can be repeated (required)
+  -h, --help              help for deprecation
+      --ignore strings    Files to ignore
+      --include strings   Only include files matching this pattern
+      --schema strings    Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -57,9 +60,10 @@ Usage:
   gql-lint deprecation [flags] queries
 
 Flags:
-  -h, --help                 help for deprecation
-      --ignore stringArray   Files to ignore. Can be repeated
-      --schema stringArray   Server's schema as file or url. Can be repeated (required)
+  -h, --help              help for deprecation
+      --ignore strings    Files to ignore
+      --include strings   Only include files matching this pattern
+      --schema strings    Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -78,6 +82,10 @@ $ gql-lint deprecation --output json --schema testdata/schemas/with_deprecations
 
 # ignores a given file glob
 $ gql-lint deprecation --output json --schema testdata/schemas/with_deprecations.gql --ignore testdata/queries/author/author_id.gql testdata/queries/author/*.gql
+{"testdata/schemas/with_deprecations.gql":[{"field":"author.books.title","file":"testdata/queries/author/author.gql","line":7,"reason":"untitled books are better"}]}
+
+# only includes files matching given file glob
+$ gql-lint deprecation --output json --schema testdata/schemas/with_deprecations.gql --include testdata/**/author.gql testdata/queries/**/*.gql
 {"testdata/schemas/with_deprecations.gql":[{"field":"author.books.title","file":"testdata/queries/author/author.gql","line":7,"reason":"untitled books are better"}]}
 
 # outputs deprecations as xcode

--- a/cmd/testdata/unused.ct
+++ b/cmd/testdata/unused.ct
@@ -5,9 +5,10 @@ Usage:
   gql-lint unused [flags] queries
 
 Flags:
-  -h, --help                 help for unused
-      --ignore stringArray   Files to ignore
-      --schema stringArray   Server's schema as file or url. Can be repeated (required)
+  -h, --help              help for unused
+      --ignore strings    Files to ignore
+      --include strings   Only include files matching this pattern
+      --schema strings    Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -20,9 +21,10 @@ Usage:
   gql-lint unused [flags] queries
 
 Flags:
-  -h, --help                 help for unused
-      --ignore stringArray   Files to ignore
-      --schema stringArray   Server's schema as file or url. Can be repeated (required)
+  -h, --help              help for unused
+      --ignore strings    Files to ignore
+      --include strings   Only include files matching this pattern
+      --schema strings    Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -35,9 +37,10 @@ Usage:
   gql-lint unused [flags] queries
 
 Flags:
-  -h, --help                 help for unused
-      --ignore stringArray   Files to ignore
-      --schema stringArray   Server's schema as file or url. Can be repeated (required)
+  -h, --help              help for unused
+      --ignore strings    Files to ignore
+      --include strings   Only include files matching this pattern
+      --schema strings    Server's schema as file or url (required)
 
 Global Flags:
       --output string   Output format. Choose between stdout, json, xcode. (default "stdout")
@@ -58,7 +61,11 @@ Schema: testdata/schemas/album.gql
 
 # outputs deprecations as json
 $ gql-lint unused --output json --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql
-{"testdata/schemas/with_deprecations.gql":[{"field":"Book.title","file":"","line":1,"reason":""}]}
+{"testdata/schemas/with_deprecations.gql":[{"field":"Book.title","line":1}]}
+
+# only includes files matching given file glob
+$ gql-lint unused --output json --include ./**/album.gql --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/**/*.gql
+{"testdata/schemas/with_deprecations.gql":[{"field":"Book.title","line":1}]}
 
 # ignores a given file blob
 $ gql-lint unused --output json --schema testdata/schemas/with_deprecations.gql --ignore testdata/queries/unused/without_title/*.gql testdata/queries/unused/**/*.gql

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -10,10 +10,11 @@ func TestQueryFiles(t *testing.T) {
 	is := is.New(t)
 
 	tests := []struct {
-		name   string
-		args   []string
-		ignore []string
-		want   []string
+		name    string
+		args    []string
+		ignore  []string
+		include []string
+		want    []string
 	}{
 		{
 			name: "expands directories",
@@ -47,11 +48,23 @@ func TestQueryFiles(t *testing.T) {
 			ignore: []string{"./testdata/**/one.gql"},
 			want:   []string{"testdata/two.gql", "testdata/nested/two.gql"},
 		},
+		{
+			name:    "removes everything not matching an include filter",
+			args:    []string{"testdata/**/*.gql"},
+			include: []string{"testdata/one.gql"},
+			want:    []string{"testdata/one.gql"},
+		},
+		{
+			name:    "removes everything not matching a nested directory include filter",
+			args:    []string{"testdata/**/*.gql"},
+			include: []string{"./**/one.gql"},
+			want:    []string{"testdata/one.gql", "testdata/nested/one.gql"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ExpandGlobs(tt.args, tt.ignore)
+			got, err := ExpandGlobs(tt.args, tt.include, tt.ignore)
 			is.NoErr(err)
 
 			is.Equal(got, tt.want)

--- a/output/output.go
+++ b/output/output.go
@@ -9,9 +9,9 @@ import (
 
 type Field struct {
 	Field             string `json:"field"`
-	File              string `json:"file"`
+	File              string `json:"file,omitempty"`
 	Line              int    `json:"line"`
-	DeprecationReason string `json:"reason"`
+	DeprecationReason string `json:"reason,omitempty"`
 }
 
 func (f *Field) Equals(b *Field) bool {


### PR DESCRIPTION
Useful if you need to process a directory that contains a lot of other things. Instead of ignoreing stuff you can now filter out just the files you need.

This also changes `--schema` and `--ignore` to support comma seperated arguments instead of the argument having to be repeated. This helps cut down the amount of processing needed to generate the argument list in some cases.