### PR TITLE
Walk schemas in alphabetical order to fix flaky tests.

### DIFF
--- a/cmd/testdata/unused.ct
+++ b/cmd/testdata/unused.ct
@@ -53,11 +53,11 @@ Schema: testdata/schemas/with_deprecations.gql
 
 # supports repeated --schema
 $ gql-lint unused --schema testdata/schemas/with_deprecations.gql --schema testdata/schemas/album.gql testdata/queries/unused/without_title/*.gql
-Schema: testdata/schemas/with_deprecations.gql
-  Book.title (line 1) is unused and can be removed 
-
 Schema: testdata/schemas/album.gql
-  Album.title (line 1) is unused and can be removed
+  Album.title (line 1) is unused and can be removed 
+
+Schema: testdata/schemas/with_deprecations.gql
+  Book.title (line 1) is unused and can be removed
 
 # outputs deprecations as json
 $ gql-lint unused --output json --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql
@@ -80,11 +80,11 @@ $ gql-lint unused --output json --schema testdata/schemas/with_deprecations.gql 
 
 # outputs for slack
 $ gql-lint unused --output markdown --schema testdata/schemas/with_deprecations.gql --schema testdata/schemas/album.gql testdata/queries/unused/without_title/*.gql
-Schema: testdata/schemas/with_deprecations.gql
-- Book.title (line `1`)
-
 Schema: testdata/schemas/album.gql
 - Album.title (line `1`)
+
+Schema: testdata/schemas/with_deprecations.gql
+- Book.title (line `1`)
 
 # outputs debug info if --verbose is used
 $ gql-lint --verbose unused --schema testdata/schemas/with_deprecations.gql testdata/queries/unused/without_title/*.gql

--- a/output/output.go
+++ b/output/output.go
@@ -30,9 +30,16 @@ func (d Data) SortByField() {
 
 type DataWalkFunc func(schema string, field Field, fieldIdx int)
 
-// Walk calls a walker function for each schema and field
+// Walk calls a walker function for each schema and field. Schemas are walked in alphabetical order.
 func (d *Data) Walk(walker DataWalkFunc) {
-	for schema, fields := range *d {
+	schemas := make([]string, 0, len(*d))
+	for k := range *d {
+		schemas = append(schemas, k)
+	}
+	sort.Strings(schemas)
+
+	for _, schema := range schemas {
+		fields := (*d)[schema]
 		for fieldIdx, f := range fields {
 			walker(schema, f, fieldIdx)
 		}


### PR DESCRIPTION
Some tests would fail as schemas are map keys and not guaranteeded to be ordered.