### PR TITLE
Fork of grahql-go-tools removed.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,15 +2,12 @@ module github.com/sketch-hq/gql-lint
 
 go 1.19
 
-// while we wait for https://github.com/wundergraph/graphql-go-tools/pull/488 to be merged and released
-replace github.com/wundergraph/graphql-go-tools => github.com/sketch-hq/graphql-go-tools v0.0.0-20230119134629-3dd6fc431bee
-
 require (
 	github.com/google/go-cmdtest v0.4.0
 	github.com/matryer/is v1.4.0
 	github.com/spf13/cobra v1.6.1
 	github.com/vektah/gqlparser/v2 v2.5.1
-	github.com/wundergraph/graphql-go-tools v1.60.6
+	github.com/wundergraph/graphql-go-tools v1.61.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/sketch-hq/graphql-go-tools v0.0.0-20230119134629-3dd6fc431bee h1:pMWSHmpPbxAvjMlvQcT1aVVtVQY691NnqD10w9L0i4U=
-github.com/sketch-hq/graphql-go-tools v0.0.0-20230119134629-3dd6fc431bee/go.mod h1:kHPC4B6vQFMohnEofRgcy37eYhoDsjzxJ4P8ZhQrV4M=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -54,6 +52,8 @@ github.com/tidwall/sjson v1.0.4 h1:UcdIRXff12Lpnu3OLtZvnc03g4vH2suXDXhBwBqmzYg=
 github.com/tidwall/sjson v1.0.4/go.mod h1:bURseu1nuBkFpIES5cz6zBtjmYeOQmEESshn7VpF15Y=
 github.com/vektah/gqlparser/v2 v2.5.1 h1:ZGu+bquAY23jsxDRcYpWjttRZrUz07LbiY77gUOHcr4=
 github.com/vektah/gqlparser/v2 v2.5.1/go.mod h1:mPgqFBu/woKTVYWyNk8cO3kh4S/f4aRFZrvOnp3hmCs=
+github.com/wundergraph/graphql-go-tools v1.61.2 h1:zO6bveWwPf7IVYJqbUffsW9sbWhhWuRTPAIjFju2xlA=
+github.com/wundergraph/graphql-go-tools v1.61.2/go.mod h1:Lsg/b4nVfNQLyJE1mjPV73O/JuhhCxH5qmaWQjitVHM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Upstream fixed a bug with quotes in field descriptions so we no longer need to use our own fork. Our own fork will be deleted once this is merged.