### PR TITLE
chore: update go-release-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             goos: darwin
     steps:
       - uses: actions/checkout@v3
-      - uses: wangyoucao577/go-release-action@v1.34
+      - uses: wangyoucao577/go-release-action@v1.52
         with:
           project_path: "./cmd"
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The previous version was not longer working to generate release assets. Updating to the current latest fixes the issue